### PR TITLE
DX-2262 Append GUID To Media ID

### DIFF
--- a/tests/media.test.js
+++ b/tests/media.test.js
@@ -16,7 +16,7 @@ describe('media', () => {
         const content = 'Hello world!';
     
         const accountId = process.env.BW_ACCOUNT_ID;
-        const mediaId = `${process.env.GITHUB_RUN_ID}-media-up-down`;
+        const mediaId = `Node-Test-Media_`.concat(Date.now); //append time in millis to avoid third-party GUID generator dependency
         const body = new FileWrapper(Buffer.from(content));
         const contentType = 'text/plain';
     


### PR DESCRIPTION
Appended time in millis since 1970, since GUID generation is not available in JavaScript without a third party dependency.